### PR TITLE
fix: Remove duplicate hbl_get_field function to prevent redeclaration…

### DIFF
--- a/includes/acf-fields.php
+++ b/includes/acf-fields.php
@@ -892,23 +892,6 @@ function hbl_save_lead_details($post_id) {
 add_action('save_post_lead', 'hbl_save_lead_details');
 
 /**
- * Helper function to get field value regardless of ACF availability
- */
-function hbl_get_field($field_name, $post_id = false) {
-    if (!$post_id) {
-        $post_id = get_the_ID();
-    }
-    
-    // Try ACF function first if available
-    if (function_exists('get_field')) {
-        return get_field($field_name, $post_id);
-    }
-    
-    // Fall back to regular post meta
-    return get_post_meta($post_id, $field_name, true);
-}
-
-/**
  * Helper function to update field value regardless of ACF availability
  */
 function hbl_update_field($field_name, $value, $post_id = false) {


### PR DESCRIPTION
## Description
This PR fixes a function redeclaration error that occurs when the plugin is activated in a WordPress Multisite network. The error was caused by the `hbl_get_field()` function being declared in both `helpers.php` and `acf-fields.php`.

## Changes Made
- Removed the duplicate `hbl_get_field()` function from `acf-fields.php`
- The function is now only defined in `helpers.php`

## Testing
- [ ] Tested plugin activation in a single site installation
- [ ] Tested plugin activation in a multisite network
- [ ] Verified that the function still works as expected in both scenarios

## Related Issues
Fixes the fatal error: "Cannot redeclare hbl_get_field()" in multisite networks